### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/rc.yaml
+++ b/.github/workflows/rc.yaml
@@ -26,7 +26,7 @@ jobs:
       - run: npm run build
       - run: docker build .
         if: github.ref != 'refs/heads/master'
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         if: github.ref == 'refs/heads/master'
         with:
           name: simonschneider/monarch


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore